### PR TITLE
Treat "UN" VR with -1 length as a sequence

### DIFF
--- a/lib/dicom/d_read.rb
+++ b/lib/dicom/d_read.rb
@@ -112,8 +112,9 @@ module DICOM
         end
       end
       # Create an Element from the gathered data:
-      if level_vr == "SQ" or tag == ITEM_TAG
-        if level_vr == "SQ"
+      # if vr is UN ("unknown") and length is -1, treat as a sequence (sec. 6.2.2 of DICOM standard)
+      if level_vr == "SQ" or tag == ITEM_TAG or (level_vr == "UN" and length == -1)
+        if level_vr == "SQ" or (level_vr == "UN" and length == -1)
           check_duplicate(tag, 'Sequence')
           unless @current_parent[tag] and !@overwrite
             @current_element = Sequence.new(tag, :length => length, :name => name, :parent => @current_parent, :vr => vr)


### PR DESCRIPTION
If the VR of an element is "UN" (unknown) and its length is -1, it should be treated as a sequence.

Relevant section: 6.2.2 (note 4) of DICOM standard
http://dicom.nema.org/dicom/2013/output/chtml/part05/sect_6.2.html#sect_6.2.2
